### PR TITLE
Date instead of Time (history tab)

### DIFF
--- a/interfaces/default/html/sabnzbd.html
+++ b/interfaces/default/html/sabnzbd.html
@@ -42,7 +42,7 @@
                 <table class="table table-striped">
                     <thead>
                     <tr>
-                        <th>Time</th>
+                        <th>Date</th>
                         <th>File</th>
                         <th>Status</th>
                         <th>Size</th>


### PR DESCRIPTION
"Date" instead of "Time". Just like couch, sick and headphones