### PR TITLE
Start & Quit Kodi

### DIFF
--- a/interfaces/default/html/kodi.html
+++ b/interfaces/default/html/kodi.html
@@ -43,7 +43,9 @@
                     <i class="caret"></i></a>
                     <ul class="dropdown-menu pull-right">
                         <li><a href="Wake" class="ajax-link" title="Send WakeOnLan"><i class="icon-off"></i> Wake</a></li>
-                        <li><a href="System?action=Suspend" class="ajax-confirm" title="Suspend kodi"><i class="icon-eye-close"></i> Suspend</a></li>
+                        <li><a href="Run" class="ajax-link" title="Start kodi"><i class="icon-off"></i> Start</a></li>
+						<li><a href="System?action=Quit" class="ajax-confirm" title="Quit kodi"><i class="icon-off"></i> Quit</a></li>
+						<li><a href="System?action=Suspend" class="ajax-confirm" title="Suspend kodi"><i class="icon-eye-close"></i> Suspend</a></li>
                         <li><a href="System?action=Reboot" class="ajax-confirm" title="Restart kodi"><i class="icon-refresh"></i> Restart</a></li>
                         <li><a href="System?action=Shutdown" class="ajax-confirm" title="Shutdown kodi"><i class="icon-off"></i> Shutdown</a></li>
                     </ul>

--- a/interfaces/default/js/settings.js
+++ b/interfaces/default/js/settings.js
@@ -91,7 +91,7 @@ $(document).ready(function () {
             msg = data ? 'Save successful' : 'Save failed';
             if ($('#kodi_server_id').is(":visible")) {
                 kodi_update_servers(0);
-                this.reset();
+                //this.reset();
             }
             if ($('#users_user_id').is(":visible")) {
                 users_update_user(0);
@@ -139,6 +139,7 @@ $(document).ready(function () {
             $('#kodi_server_username').val(data.username);
             $('#kodi_server_password').val(data.password);
             $('#kodi_server_mac').val(data.mac);
+			$('#kodi_server_starterport').val(data.starterport);
             $("button:reset:visible").html('Delete').addClass('btn-danger').click(function (e) {
                 var name = item.find('option:selected').text();
                 if (!confirm('Delete ' + name)) return;

--- a/modules/kodi.py
+++ b/modules/kodi.py
@@ -24,14 +24,20 @@ class KodiServers(SQLObject):
     username = StringCol(default=None)
     password = StringCol(default=None)
     mac = StringCol(default=None)
-
-
+    class sqlmeta:
+        fromDatabase = True
+	
 class Kodi(object):
     def __init__(self):
         """ Add module to list of modules on load and set required settings """
         self.logger = logging.getLogger('modules.kodi')
 
         KodiServers.createTable(ifNotExists=True)
+        try:
+            KodiServers.sqlmeta.addColumn(IntCol('starterport'), changeSchema=True)
+        except Exception, e:
+            self.logger.exception(e)
+
         htpc.MODULES.append({
             'name': 'KODI',
             'id': 'kodi',
@@ -83,7 +89,11 @@ class Kodi(object):
                  'name': 'kodi_server_password'},
                 {'type': 'text',
                  'label': 'Mac addr.',
-                 'name': 'kodi_server_mac'}
+                 'name': 'kodi_server_mac'},
+                {'type': 'text',
+                 'label': 'XBMC Starter port',
+                 'placeholder': '9',
+                 'name': 'kodi_server_starterport'}
             ]
         })
         server = htpc.settings.get('kodi_current_server', 0)
@@ -147,8 +157,12 @@ class Kodi(object):
     @require()
     @cherrypy.tools.json_out()
     def setserver(self, kodi_server_id, kodi_server_name, kodi_server_host, kodi_server_port,
-            kodi_server_username=None, kodi_server_password=None, kodi_server_mac=None):
+            kodi_server_username=None, kodi_server_password=None, kodi_server_mac=None, kodi_server_starterport=''):
         """ Create a server if id=0, else update a server """
+        if kodi_server_starterport == '':
+            kodi_server_starterport = None
+        else:
+            kodi_server_starterport = int(kodi_server_starterport)
         if kodi_server_id == "0":
             self.logger.debug("Creating kodi-Server in database")
             try:
@@ -157,7 +171,8 @@ class Kodi(object):
                         port=int(kodi_server_port),
                         username=kodi_server_username,
                         password=kodi_server_password,
-                        mac=kodi_server_mac)
+                        mac=kodi_server_mac,
+						starterport=kodi_server_starterport)
                 self.changeserver(server.id)
                 return 1
             except Exception, e:
@@ -174,6 +189,7 @@ class Kodi(object):
                 server.username = kodi_server_username
                 server.password = kodi_server_password
                 server.mac = kodi_server_mac
+                server.starterport = kodi_server_starterport
                 return 1
             except SQLObjectNotFound, e:
                 self.logger.error("Unable to update kodi-Server " + server.name + " in database")
@@ -628,6 +644,10 @@ class Kodi(object):
     def System(self, action=''):
         """ Various system commands """
         kodi = Server(self.url('/jsonrpc', True))
+        if action == 'Quit':
+            self.logger.info("Exiting kodi")
+            kodi.Application.Quit()
+            return 'Exiting kodi.'
         if action == 'Shutdown':
             self.logger.info("Shutting down kodi")
             kodi.System.Shutdown()
@@ -666,6 +686,22 @@ class Kodi(object):
             self.logger.exception(e)
             self.logger.error("Unable to send WOL packet")
             return "Unable to send WOL packet"
+
+    @cherrypy.expose()
+    @require()
+    @cherrypy.tools.json_out()
+    def Run(self):
+        """ Send XBMC Starter packet """
+        self.logger.info("Sending XBMC Starter packet")
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            s.sendto("YatseStart-Xbmc", (self.current.host, self.current.starterport))
+            self.logger.info("XBMC Starter package sent to %s:%s", self.current.host, self.current.starterport)
+            return "XBMC Starter packet sent"
+        except Exception, e:
+            self.logger.exception(e)
+            self.logger.error("Unable to send XBMC Starter packet")
+            return "Unable to send XBMC Starter packet"
 
     @cherrypy.expose()
     @require()


### PR DESCRIPTION
Add the ability to start and quit kodi.

To start kodi, it sends a udp packet to XBMC Starter

(http://yatse.leetzone.org/redmine/projects/androidwidget/wiki/XbmcStarter)

Add starterport column to kodi_servers table.

Fixed a bug where kodi servers saved settings dialog do not show.

Allow kodi_starterport to be empty