### PR TITLE
Menu order fix for IE

### DIFF
--- a/interfaces/default/html/base.html
+++ b/interfaces/default/html/base.html
@@ -162,7 +162,7 @@ ${self.body()}
     menus = {}
     % for m in htpc.MODULES:
         % if s.get(m.get('id')+'_enable') and m.get('id') != 'nzbsearch':
-            menus['nav-${m.get('id')}'] = '<li class="nav-menu-item" id="nav-${m.get('id')|h, entity}"><a href="${htpc.WEBDIR}${m.get('id')|h, entity}/">${s.get(m.get('id')+'_name')|h, entity}</a></li>';
+                menus['nav-${m.get('id')}'] = '<li class="nav-menu-item" id="nav-${m.get('id')|h, entity}"><a href="${htpc.WEBDIR}${m.get('id')|h, entity}/">${m.get('id').capitalize() if s.get(m.get('id')+'_name').strip() == "" else s.get(m.get('id')+'_name')|h, entity}</a></li>';
         %endif
     % endfor
     menu_order = "${settings.get('menu_order', 0)}";

--- a/interfaces/default/html/base.html
+++ b/interfaces/default/html/base.html
@@ -162,7 +162,7 @@ ${self.body()}
     menus = {}
     % for m in htpc.MODULES:
         % if s.get(m.get('id')+'_enable') and m.get('id') != 'nzbsearch':
-                menus['nav-${m.get('id')}'] = '<li class="nav-menu-item" id="nav-${m.get('id')|h, entity}"><a href="${htpc.WEBDIR}${m.get('id')|h, entity}/">${m.get('id').capitalize() if s.get(m.get('id')+'_name').strip() == "" else s.get(m.get('id')+'_name')|h, entity}</a></li>';
+                menus['nav-${m.get('id')}'] = '<li class="nav-menu-item" id="nav-${m.get('id')|h, entity}"><a href="${htpc.WEBDIR}${m.get('id')|h, entity}/">${m.get('name') if s.get(m.get('id')+'_name').strip() == "" else s.get(m.get('id')+'_name')|h, entity}</a></li>';
         %endif
     % endfor
     menu_order = "${settings.get('menu_order', 0)}";

--- a/interfaces/default/js/default.js
+++ b/interfaces/default/js/default.js
@@ -136,8 +136,8 @@ $(document).ready(function () {
             }
         }
     }
-    for (item in menus) {  //build aditional items not in menu_order
-        menu_ordered += menus[item];
+    for (menu_item in menus) {  //build aditional items not in menu_order
+        menu_ordered += menus[menu_item];
     }
     $("#nav-menu").prepend(menu_ordered) // prepend to others dropdown item
 })


### PR DESCRIPTION
Add a default name if "menu name" setting is blank (base.html)

Change "item" variable name to "menu_item" since "item" is a reserved
word (default.js)