### PR TITLE
Update to dash.js for episode art.

### DIFF
--- a/interfaces/default/js/dash.js
+++ b/interfaces/default/js/dash.js
@@ -79,8 +79,15 @@ function loadRecentTVshows () {
             var itemDiv = $('<div>').addClass('item carousel-item')
 
             if (i == 0) itemDiv.addClass('active')
+            
+            		var imgp;
+		if (episode.thumbnail) {
+   		 imgp = episode.thumbnail;
+		} else {
+   		imgp = episode.fanart
+		}
 
-            var src = WEBDIR + "kodi/GetThumb?h=240&w=430&thumb="+encodeURIComponent(episode.fanart)
+            var src = WEBDIR + "kodi/GetThumb?h=240&w=430&thumb="+encodeURIComponent(episode.thumbnail)
             itemDiv.attr('style', 'background-image: url("' + src + '")')
 
             itemDiv.append($('<div>').addClass('carousel-caption').click(function() {

--- a/interfaces/default/js/dash.js
+++ b/interfaces/default/js/dash.js
@@ -87,7 +87,7 @@ function loadRecentTVshows () {
    		imgp = episode.fanart
 		}
 
-            var src = WEBDIR + "kodi/GetThumb?h=240&w=430&thumb="+encodeURIComponent(episode.thumbnail)
+            var src = WEBDIR + "kodi/GetThumb?h=240&w=430&thumb="+encodeURIComponent(imgp)
             itemDiv.attr('style', 'background-image: url("' + src + '")')
 
             itemDiv.append($('<div>').addClass('carousel-caption').click(function() {

--- a/interfaces/default/js/dash.js
+++ b/interfaces/default/js/dash.js
@@ -79,13 +79,13 @@ function loadRecentTVshows () {
             var itemDiv = $('<div>').addClass('item carousel-item')
 
             if (i == 0) itemDiv.addClass('active')
-            
-            		var imgp;
-		if (episode.thumbnail) {
-   		 imgp = episode.thumbnail;
-		} else {
-   		imgp = episode.fanart
-		}
+           
+	var imgp;
+	if (episode.thumbnail) {
+	    imgp = episode.thumbnail;
+	} else {
+	    imgp = episode.fanart
+	}
 
             var src = WEBDIR + "kodi/GetThumb?h=240&w=430&thumb="+encodeURIComponent(imgp)
             itemDiv.attr('style', 'background-image: url("' + src + '")')

--- a/interfaces/default/js/dash.js
+++ b/interfaces/default/js/dash.js
@@ -80,12 +80,12 @@ function loadRecentTVshows () {
 
             if (i == 0) itemDiv.addClass('active')
            
-	var imgp;
-	if (episode.thumbnail) {
-	    imgp = episode.thumbnail;
-	} else {
-	    imgp = episode.fanart
-	}
+	    var imgp;
+	    if (episode.thumbnail) {
+	    	imgp = episode.thumbnail;
+	    } else {
+	    	imgp = episode.fanart
+	    }
 
             var src = WEBDIR + "kodi/GetThumb?h=240&w=430&thumb="+encodeURIComponent(imgp)
             itemDiv.attr('style', 'background-image: url("' + src + '")')


### PR DESCRIPTION
Update to change episode.fanart to display episode.thumbnail instead, if no episode thumbnail then display episode fanart instead.

Test on default, slate, cerulean and also iPhone 5s, iPad 2.
