### PR TITLE
Improvements to Sonarr module

### DIFF
--- a/interfaces/default/css/base.css
+++ b/interfaces/default/css/base.css
@@ -169,3 +169,6 @@ table th.tablesorter-header {
 .rg-client {
 	font-size: 18px !important;
 }
+.tooltip-inner {
+	white-space: pre-wrap !important;
+}

--- a/interfaces/default/html/dash.html
+++ b/interfaces/default/html/dash.html
@@ -115,7 +115,7 @@ settings = self.attr.settings
                         <tr>
                             <th>Showname</th>
                             <th>Episode</th>
-                            <th>Airdate</th>
+                            <th>Air Date</th>
                         </tr>
                     </thead>
                     <tbody id="nextaired_sickbeard_table_body"></tbody>
@@ -130,7 +130,7 @@ settings = self.attr.settings
                         <tr>
                             <th>Showname</th>
                             <th>Episode</th>
-                            <th>Airdate</th>
+                            <th>Air Date</th>
                         </tr>
                     </thead>
                     <tbody id="calendar_table_body"></tbody>
@@ -145,7 +145,7 @@ settings = self.attr.settings
                         <tr>
                             <th>Showname</th>
                             <th>Episode</th>
-                            <th>Airdate</th>
+                            <th>Air Date</th>
                         </tr>
                     </thead>
                     <tbody id="nextaired_sickrage_table_body"></tbody>

--- a/interfaces/default/html/sickbeard.html
+++ b/interfaces/default/html/sickbeard.html
@@ -39,7 +39,7 @@
                         <tr>
                             <th>Showname</th>
                             <th>Episode</th>
-                            <th>Airdate</th>
+                            <th>Air Date</th>
                         </tr>
                     </thead>
                     <tbody id="nextaired_table_body"></tbody>

--- a/interfaces/default/html/sickbeard_view.html
+++ b/interfaces/default/html/sickbeard_view.html
@@ -66,7 +66,7 @@
                 <tr>
                     <th>Episode</th>
                     <th>Name</th>
-                    <th>Airdate</th>
+                    <th>Air Date</th>
                     <th>status</th>
                     <th>Quality</th>
                     <th class="span1">Search</th>

--- a/interfaces/default/html/sickrage.html
+++ b/interfaces/default/html/sickrage.html
@@ -49,7 +49,7 @@
                         <tr>
                             <th>Showname</th>
                             <th>Episode</th>
-                            <th>Airdate</th>
+                            <th>Air Date</th>
                             <th>Action</th>
                         </tr>
                     </thead>

--- a/interfaces/default/html/sickrage_view.html
+++ b/interfaces/default/html/sickrage_view.html
@@ -76,7 +76,7 @@
                     <tr>
                         <th>Episode</th>
                         <th>Name</th>
-                        <th>Airdate</th>
+                        <th>Air Date</th>
                         <th>status</th>
                         <th>Quality</th>
                         <th>Action</th>

--- a/interfaces/default/html/sonarr.html
+++ b/interfaces/default/html/sonarr.html
@@ -59,7 +59,8 @@
                         <tr>
                             <th>Showname</th>
                             <th>Episode</th>
-                            <th>Airdate</th>
+                            <th>Title</th>
+                            <th>Air Date</th>
                         </tr>
                     </thead>
                     <tbody id="calendar_table_body"></tbody>
@@ -72,7 +73,7 @@
                             <th>Date</th>
                             <th>Action</th>
                             <th>Showname</th>
-                            <th>Episode</th>
+                            <th>Title</th>
                             <th>Status</th>
                             <th>Quality</th>
                         </tr>
@@ -80,7 +81,7 @@
                     <tbody id="history_table_body"></tbody>
                 </table>
             </div>
-            <div id="log" class="tab-pane">
+            <!--<div id="log" class="tab-pane">
                 <table class="table table-striped">
                     <thead>
                         <tr>
@@ -89,7 +90,7 @@
                     </thead>
                     <tbody id="log_table_body"></tbody>
                 </table>
-            </div>
+            </div>-->
             <div class="spinner"></div>
         </div>
     </div>

--- a/interfaces/default/html/sonarr_view.html
+++ b/interfaces/default/html/sonarr_view.html
@@ -73,7 +73,7 @@
                 <tr>
                     <th>Episode</th>
                     <th>Name</th>
-                    <th>Airdate</th>
+                    <th>Air Date</th>
                     <th>status</th>
                     <th>Quality</th>
                     <th class="span1">Search</th>

--- a/interfaces/default/js/dash.js
+++ b/interfaces/default/js/dash.js
@@ -323,7 +323,7 @@ function loadsonarrCalendar(options) {
             var img = makeIcon('fa fa-info-circle', cal.overview);
             row.append(
             $('<td>').append(name),
-            $('<td>').html('S' + cal.seasonNumber.pad() + 'E' + cal.episodeNumber.pad() + '&nbsp').append(img),
+            $('<td>').html('S' + pad(cal.seasonNumber, 2) + 'E' + pad(cal.episodeNumber, 2) + '&nbsp').append(img),
             $('<td>').text(moment(cal.airDateUtc).fromNow())
             )
 

--- a/interfaces/default/js/dash.js
+++ b/interfaces/default/js/dash.js
@@ -318,10 +318,12 @@ function loadsonarrCalendar(options) {
         $.each(result, function (i, cal) {
           if (i >= 5) return
             var name = $('<a>').attr('href', 'sonarr/View/' + cal.seriesId + '/' + cal.series.tvdbId + '#' + cal.seasonNumber).html(cal.series.title)
-            var row = $('<tr>');
+            var number
+            var row = $('<tr>')
+            var img = makeIcon('fa fa-info-circle', cal.overview);
             row.append(
             $('<td>').append(name),
-            $('<td>').text(cal.title),
+            $('<td>').html('S' + cal.seasonNumber.pad() + 'E' + cal.episodeNumber.pad() + '&nbsp').append(img),
             $('<td>').text(moment(cal.airDateUtc).fromNow())
             )
 

--- a/interfaces/default/js/default.js
+++ b/interfaces/default/js/default.js
@@ -267,3 +267,9 @@ $('.dropdown-toggle').click(function(e) {
     }
   }, this), 0);
 });
+// Pad numbers with leading zero, e.g. S1E1 becomes S01E01, useful for episode numbering
+Number.prototype.pad = function(size) {
+      var s = String(this);
+      while (s.length < (size || 2)) {s = "0" + s;}
+      return s;
+    }

--- a/interfaces/default/js/default.js
+++ b/interfaces/default/js/default.js
@@ -267,9 +267,3 @@ $('.dropdown-toggle').click(function(e) {
     }
   }, this), 0);
 });
-// Pad numbers with leading zero, e.g. S1E1 becomes S01E01, useful for episode numbering
-Number.prototype.pad = function(size) {
-      var s = String(this);
-      while (s.length < (size || 2)) {s = "0" + s;}
-      return s;
-    }

--- a/interfaces/default/js/sonarr.js
+++ b/interfaces/default/js/sonarr.js
@@ -199,7 +199,7 @@ function calendar() {
             var img = makeIcon('fa fa-info-circle', cal.overview);
             row.append(
             $('<td>').append(name),
-            $('<td>').text('S' + cal.seasonNumber.pad() + 'E' + cal.episodeNumber.pad()),
+            $('<td>').text('S' + pad(cal.seasonNumber, 2) + 'E' + pad(cal.episodeNumber, 2)),
             $('<td>').html(cal.title + '&nbsp').append(img),
             $('<td>').text(moment(cal.airDateUtc).calendar()));
             $('#calendar_table_body').append(row);

--- a/interfaces/default/js/sonarr.js
+++ b/interfaces/default/js/sonarr.js
@@ -199,6 +199,7 @@ function calendar() {
             var img = makeIcon('fa fa-info-circle', cal.overview);
             row.append(
             $('<td>').append(name),
+            $('<td>').text('S' + cal.seasonNumber.pad() + 'E' + cal.episodeNumber.pad()),
             $('<td>').html(cal.title + '&nbsp').append(img),
             $('<td>').text(moment(cal.airDateUtc).calendar()));
             $('#calendar_table_body').append(row);


### PR DESCRIPTION
Added episode numbering to Sonarr calendar view.

On Sonarr dash module episode titles are always so truncated that they aren't really useful, so I've replaced the title with the epsode number and added a tooltip next to the episode number which gives the overview of that episode.  I think it makes the Sonarr dash module more informative.

Minor typo fixes.
