### PR TITLE
Fix: Issue where Sickbeard test would always fail

### DIFF
--- a/modules/sickbeard.py
+++ b/modules/sickbeard.py
@@ -70,7 +70,7 @@ class Sickbeard(object):
             if not sickbeard_basepath:
                 sickbeard_basepath = fix_basepath(sickbeard_basepath)
 
-            url = "http%s://%s:%s%sapi/%s/?cmd=sb.ping" % (ssl, striphttp(sickbeard_host), sickbeard_port, sickbeard_apikey)
+            url = "http%s://%s:%s/api/%s/?cmd=sb.ping" % (ssl, striphttp(sickbeard_host), sickbeard_port, sickbeard_apikey)
 
             self.logger.debug("Trying to contact sickbeard via " + url)
             response = loads(urlopen(url, timeout=10).read())


### PR DESCRIPTION
There was an extra string replacement in the URL causing the test to always fail.
