### PR TITLE
Fixed: Aligned IPv6 text left

### DIFF
--- a/interfaces/default/css/dash.css
+++ b/interfaces/default/css/dash.css
@@ -123,3 +123,7 @@
 #dash_disks .table{
   table-layout: auto !important;
 }
+
+.ip{
+width:360px;
+}

--- a/interfaces/default/js/dash.js
+++ b/interfaces/default/js/dash.js
@@ -546,7 +546,7 @@ function loadsysinfo(options) {
         $('<td>').append(
           $('<div>').append(
             $('<div class="pull-left">').html(result.localip),
-            $('<div class="pull-right">').html(result.externalip)
+            $('<div class="pull-left">').html(result.externalip)
           )
         )
       ),

--- a/interfaces/default/js/dash.js
+++ b/interfaces/default/js/dash.js
@@ -546,7 +546,7 @@ function loadsysinfo(options) {
         $('<td>').append(
           $('<div>').append(
             $('<div class="pull-left">').html(result.localip),
-            $('<div class="pull-left">').html(result.externalip)
+            $('<div class="pull-right">').html(result.externalip)
           )
         )
       ),

--- a/interfaces/default/js/dash.js
+++ b/interfaces/default/js/dash.js
@@ -543,7 +543,7 @@ function loadsysinfo(options) {
 
       $('<tr>').append(
         $('<td>').text('IP'),
-        $('<td>').append(
+        $('<td class="ip">').append(
           $('<div>').append(
             $('<div class="pull-left">').html(result.localip),
             $('<div class="pull-right">').html(result.externalip)


### PR DESCRIPTION
Not sure if intended, ipv6 was aligned right, when ipv4 is aligned left:
![before](https://cloud.githubusercontent.com/assets/3500612/20075813/b6efb0d4-a52d-11e6-9c3c-0dbd4121dfcd.png)

![after](https://cloud.githubusercontent.com/assets/3500612/20075814/b6f3456e-a52d-11e6-8bf4-ddcb4ce5a462.png)