### PR TITLE
Modification to support Vuze Remote + Transmission Speed Limit Fixes

### DIFF
--- a/interfaces/default/js/transmission.js
+++ b/interfaces/default/js/transmission.js
@@ -214,14 +214,14 @@ function session() {
     $.ajax({
         url: WEBDIR + 'transmission/session',
         success: function (response) {
-			if(response["arguments"]["speed-limit-down-enabled"])
-				$('#transmission_speed_down').attr('placeholder', response["arguments"]["speed-limit-down"]);
-			else
-				$('#transmission_speed_down').attr('placeholder', 0);
-			if(response["arguments"]["speed-limit-up"])
-				$('#transmission_speed_up').attr('placeholder', response["arguments"]["speed-limit-up"]);
-			else
-				$('#transmission_speed_up').attr('placeholder', 0);
+            if(response["arguments"]["speed-limit-down-enabled"])
+                $('#transmission_speed_down').attr('placeholder', response["arguments"]["speed-limit-down"]);
+            else
+                $('#transmission_speed_down').attr('placeholder', 0);
+            if(response["arguments"]["speed-limit-up"])
+                $('#transmission_speed_up').attr('placeholder', response["arguments"]["speed-limit-up"]);
+            else
+                $('#transmission_speed_up').attr('placeholder', 0);
         }
 
     });

--- a/interfaces/default/js/transmission.js
+++ b/interfaces/default/js/transmission.js
@@ -214,8 +214,14 @@ function session() {
     $.ajax({
         url: WEBDIR + 'transmission/session',
         success: function (response) {
-            $('#transmission_speed_down').attr('placeholder', response["arguments"]["speed-limit-down"]);
-            $('#transmission_speed_up').attr('placeholder', response["arguments"]["speed-limit-up"]);
+			if(response["arguments"]["speed-limit-down-enabled"])
+				$('#transmission_speed_down').attr('placeholder', response["arguments"]["speed-limit-down"]);
+			else
+				$('#transmission_speed_down').attr('placeholder', 0);
+			if(response["arguments"]["speed-limit-up"])
+				$('#transmission_speed_up').attr('placeholder', response["arguments"]["speed-limit-up"]);
+			else
+				$('#transmission_speed_up').attr('placeholder', 0);
         }
 
     });

--- a/modules/transmission.py
+++ b/modules/transmission.py
@@ -58,7 +58,7 @@ class Transmission(object):
 
             basepath = fix_basepath(basepath)
 
-            url = 'http://%s:%s%srpc/' % (host, str(port), basepath)
+            url = 'http://%s:%s%srpc' % (host, str(port), basepath)
 
         return url
 
@@ -90,7 +90,7 @@ class Transmission(object):
 
         if not basepath:
             basepath = fix_basepath('/transmission/')
-        url = 'http://%s:%s%srpc/' % (striphttp(host), port, basepath)
+        url = 'http://%s:%s%srpc' % (striphttp(host), port, basepath)
 
         # format post data
         data = {'method': 'session-get'}
@@ -219,7 +219,7 @@ class Transmission(object):
 
         basepath = fix_basepath(basepath)
 
-        url = 'http://%s:%s%srpc/' % (host, str(port), basepath)
+        url = 'http://%s:%s%srpc' % (host, str(port), basepath)
 
         # format post data
         data = {'method': method}

--- a/modules/transmission.py
+++ b/modules/transmission.py
@@ -131,7 +131,7 @@ class Transmission(object):
     @cherrypy.tools.json_out()
     def set_downspeed(self, speed):
         if int(speed) == 0:
-            self.fetch('session-set', {'speed-limit-down': False})
+            return self.fetch('session-set', {'speed-limit-down-enabled': False})
         return self.fetch('session-set', {'speed-limit-down': int(speed), 'speed-limit-down-enabled': True})
 
     @cherrypy.expose()
@@ -139,9 +139,8 @@ class Transmission(object):
     @cherrypy.tools.json_out()
     def set_upspeed(self, speed):
         if int(speed) == 0:
-            self.fetch('session-set', {'speed-limit-up': 'false'})
-        else:
-            return self.fetch('session-set', {'speed-limit-up': int(speed), 'speed-limit-up-enabled': 'true'})
+            return self.fetch('session-set', {'speed-limit-up-enabled': False})
+        return self.fetch('session-set', {'speed-limit-up': int(speed), 'speed-limit-up-enabled': True})
 
     @cherrypy.expose()
     @require(member_of(htpc.role_user))


### PR DESCRIPTION
After this modification you are able to use Transmission module with Vuze Remote.
Vuze Remote json-rpc interface is compatible with Transmission one, but the slash at the end of connection path needed to be removed. Of course it still works with Transmission too.