### PR TITLE
working CentOS 7 systemd file

### DIFF
--- a/initscripts/systemd.centOS 7
+++ b/initscripts/systemd.centOS 7
@@ -1,3 +1,5 @@
+# This systemd unit file works for CentOS 7
+
 [Unit]
   Description=HTPC Manager Daemon
   After=network.target
@@ -6,11 +8,8 @@
   User=<user>
   Group=<user>
   Type=forking
-  ExecStart=/usr/bin/python /path/to/HTPCManager/Htpc.py --daemon --datadir </path/to/HTPCManager>/userdata --pid </path/to/HTPCManager>/userdata/htpcmanager.pid
+  ExecStart=-/usr/bin/python /path/to/HTPCManager/Htpc.py --daemon --datadir </path/to/HTPCManager>/userdata --pid </path/to/HTPCManager>/userdata/htpcmanager.pid
   PIDFile=</path/to/HTPCManager>/userdata/htpcmanager.pid
-  KillMode=process
-  Restart=on-failure
      
 [Install]
   WantedBy=multi-user.target
-


### PR DESCRIPTION
not sure the "stolen" one ever worked on Ubuntu. It certainly didn't on RHEL/CentOS, so this one will presumably work on all systemd based installs