### PR TITLE
Added auto-refresh setting to dashboard

### DIFF
--- a/interfaces/default/html/dash.html
+++ b/interfaces/default/html/dash.html
@@ -1,5 +1,9 @@
 <%inherit file="base.html"/>
 <% settings = self.attr.settings %>
+<script>
+  var dash_refresh_interval = 0; // type-cast to a number in case of bad values in the database.
+  dash_refresh_interval = ${settings.get('dash_refresh_interval', 0)};
+</script>
 <div class="container-fluid dashboard" id="dashboard">
     <div class="content" id="dash-content">
     </div>

--- a/interfaces/default/html/settings.html
+++ b/interfaces/default/html/settings.html
@@ -123,7 +123,9 @@
                     {'type':'bool', 'label':'Show Radarr calendar', 'name':'dash_radarr_calendar',
                         'checked':bool(settings.get('dash_radarr_calendar', 0))},
                 {'type':'bool', 'label':'Show Upcoming Albums (List)', 'name':'dash_upcoming_albums_list',
-                  'checked':bool(settings.get('dash_upcoming_albums_list', 0))}
+                  'checked':bool(settings.get('dash_upcoming_albums_list', 0))},
+                {'type':'text', 'label':'Refresh dashboard widgets interval', 'name':'dash_refresh_interval',
+                  'value':settings.get('dash_refresh_interval', '0'), 'desc':'Interval in seconds. 0 to disable.\n(Bug:0 will display as False)'}
             ])}
 
             <form class="form-horizontal tab-pane" id="other" method="POST">

--- a/interfaces/default/js/dash.js
+++ b/interfaces/default/js/dash.js
@@ -924,3 +924,14 @@ $(document).ready(function() {
     }
   }
 })
+
+if ( dash_refresh_interval > 0 ) {
+  setInterval(function () {
+    loaduTorrent();
+    loadqbit();
+    loadsysinfo();
+    loaddiskinfo();
+    loadsmartinfo();
+  }, 1000 * dash_refresh_interval ) // timer uses miliseconds
+}
+


### PR DESCRIPTION
Works, seems to be robust.
Contains some hacky type-cast stuff to make sure that bogus data (ie text instead of digits) in the refresh interval setting field does not break the dash itself.
I am not convinced that the database value should be fetched and assigned in dash.html (as opposed to dash.js) but every time I try to do it differently it breaks the dashboard page.