### PR TITLE
Add actions to Sonarr+Radarr, plus general enhancements

### DIFF
--- a/interfaces/default/css/sonarr.css
+++ b/interfaces/default/css/sonarr.css
@@ -19,3 +19,13 @@
     width: 100%;
     color: black;
 }
+
+span.icon-sonarr {
+	cursor: default;
+}
+
+span.disabled {
+	cursor: not-allowed!important;
+    opacity: 0.7;
+	color: grey;
+}

--- a/interfaces/default/html/dash.html
+++ b/interfaces/default/html/dash.html
@@ -186,7 +186,7 @@
                             <th>Air Date</th>
                         </tr>
                     </thead>
-                    <tbody id="calendar_table_body"></tbody>
+                    <tbody id="dash_sonarr_table_body"></tbody>
                 </table>
             </div>
             %endif
@@ -200,7 +200,7 @@
                             <th>Release Date</th>
                         </tr>
                     </thead>
-                    <tbody id="radarr_calendar_table_body"></tbody>
+                    <tbody id="dash_radarr_table_body"></tbody>
                 </table>
             </div>
             %endif
@@ -277,7 +277,7 @@
             %endif
             %if settings.get('dash_sysinfo', 0):
             <div class="span4  dash-module mofa" id="dash_sysinfo">
-                <h3><a href="stats">System info</a></h3>
+                <h3><a href="stats">System Info</a></h3>
                 <table class="table table-striped table-main">
                     <tbody id="dash_sysinfo_table_body"></tbody>
 

--- a/interfaces/default/html/radarr.html
+++ b/interfaces/default/html/radarr.html
@@ -33,7 +33,7 @@
         <li class="active"><a href="#tvshows" data-toggle="tab">Movies</a></li>
         <li><a href="#calendar_tab" data-toggle="tab">Calendar</a></li>
         <li><a href="#history" data-toggle="tab">History</a></li>
-        <!--<li><a href="#log" data-toggle="tab">Log</a></li>-->
+        <li id="alerts_li" class="disabled"><a href="#alerts" data-toggle="tab" id="alerts_tab"></a></li>
       </ul>
       <div class="tab-content">
         <div id="tvshows" class="tab-pane mofa active">
@@ -46,6 +46,7 @@
                 <th>Studio</th>
                 <th>Downloaded</th>
                 <th>Quality</th>
+                <th>Actions</th>
               </tr>
             </thead>
             <tbody id="tvshows_table_body"></tbody>
@@ -79,16 +80,18 @@
             <tbody id="history_table_body"></tbody>
           </table>
         </div>
-        <!--<div id="log" class="tab-pane mofa">
-                <table class="table table-striped">
-                    <thead>
-                        <tr>
-                            <th>Logitem</th>
-                        </tr>
-                    </thead>
-                    <tbody id="log_table_body"></tbody>
-                </table>
-            </div>-->
+        <div id="alerts" id="alerts_tab" class="tab-pane">
+					<table class="table table-striped">
+							<thead>
+									<tr>
+											<th class="span1">Severity</th>
+											<th class="span4">Message</th>
+											<th></th>
+									</tr>
+							</thead>
+							<tbody id="alerts_table_body"></tbody>
+					</table>
+        </div>
         <div class="spinner"></div>
       </div>
     </div>

--- a/interfaces/default/html/sonarr.html
+++ b/interfaces/default/html/sonarr.html
@@ -50,7 +50,7 @@
         <li class="active"><a href="#tvshows" data-toggle="tab">TV Shows</a></li>
         <li><a href="#calendar_tab" data-toggle="tab">Calendar</a></li>
         <li><a href="#history" data-toggle="tab">History</a></li>
-        <!--<li><a href="#log" data-toggle="tab">Log</a></li>-->
+        <li id="alerts_li" class="disabled"><a href="#alerts" data-toggle="tab" id="alerts_tab"></a></li>
       </ul>
       <div class="tab-content">
         <div id="tvshows" class="tab-pane mofa active">
@@ -59,10 +59,11 @@
               <tr>
                 <th data-ignore-articles="en" data-sorter="ignoreArticles">Showname</th>
                 <th>Status</th>
-                <th>Next ep</th>
+                <th>Next Ep</th>
                 <th>Downloads</th>
                 <th>Network</th>
                 <th>Quality</th>
+                <th>Actions</th>
               </tr>
             </thead>
             <tbody id="tvshows_table_body"></tbody>
@@ -99,16 +100,18 @@
             <tbody id="history_table_body"></tbody>
           </table>
         </div>
-        <!--<div id="log" class="tab-pane mofa">
-                <table class="table table-striped">
-                    <thead>
-                        <tr>
-                            <th>Logitem</th>
-                        </tr>
-                    </thead>
-                    <tbody id="log_table_body"></tbody>
-                </table>
-            </div>-->
+        <div id="alerts" class="tab-pane">
+					<table class="table table-striped">
+							<thead>
+									<tr>
+											<th class="span1">Severity</th>
+											<th class="span4">Message</th>
+											<th></th>
+									</tr>
+							</thead>
+							<tbody id="alerts_table_body"></tbody>
+					</table>
+        </div>
         <div class="spinner"></div>
       </div>
     </div>

--- a/interfaces/default/html/stats.html
+++ b/interfaces/default/html/stats.html
@@ -7,7 +7,11 @@ webdir = htpc.WEBDIR
 <div class="container-fluid">
   <div class="content">
     <h1 class="page-header page-title">
+		% if webinterface:
+      <a href="${webinterface}" ${'class="useiframe"' if settings.get('app_open_otherlink_in_iframe') else 'target="_blank"'} title="Open ${webinterface}">${settings.get('stats_name', 'Stats')}</a>
+		% else:
       <span>${settings.get('stats_name', 'Stats')}</span>
+    % endif
 	% if settings.get('stats_psutil_enabled'):
       <small>
         <i class="fa fa-arrow-down"></i><span id="stat-recv"></span>

--- a/interfaces/default/html/torrentsearch.html
+++ b/interfaces/default/html/torrentsearch.html
@@ -3,7 +3,11 @@
 <div class="container-fluid">
     <div class="content">
       <h1 class="page-header page-title">
+				% if webinterface:
+					<a href="${webinterface}" ${'class="useiframe"' if settings.get('app_open_otherlink_in_iframe') else 'target="_blank"'} title="Open ${webinterface}">${settings.get('torrentsearch_name', 'Torrent Search')}</a>
+				% else:
           ${settings.get('torrentsearch_name', 'Torrent Search')}
+				% endif
       </h1>
 
       <form class="well form-inline">

--- a/interfaces/default/js/dash.js
+++ b/interfaces/default/js/dash.js
@@ -782,7 +782,8 @@ function dasherror(i, msg) {
 
 function loadsysinfo(options) {
   start_refresh('sysinfo', 'loadsysinfo');
-  $.getJSON(WEBDIR + 'stats/sysinfodash', function(result) {
+  // delay function by a few ms else cpu usage displays high due to other things refreshing
+  setTimeout( function(){ $.getJSON(WEBDIR + 'stats/sysinfodash', function(result) {
     $('#dash_sysinfo_table_body').append(
       $('<tr>').append(
         $('<td>').html('CPU'),
@@ -823,6 +824,7 @@ function loadsysinfo(options) {
   }).always(function() {
     end_refresh('sysinfo');
   });
+  }, 50);
 }
 
 function loaddiskinfo() {
@@ -1136,11 +1138,11 @@ if ( dash_refresh_interval > 0 ) {
   setInterval(function () {
     loaduTorrent();
     loadqbit();
-    loadsysinfo();
     loaddiskinfo();
     loadsmartinfo();
     loadsonarrCalendar();
     loadRadarrCalendar();
+    loadsysinfo();
   }, 1000 * dash_refresh_interval ) // timer uses miliseconds
 }
 

--- a/interfaces/default/js/utorrent.js
+++ b/interfaces/default/js/utorrent.js
@@ -142,7 +142,7 @@ function getTorrents() {
                             + '<br><small><i class="fa fa-long-arrow-down"></i> ' + getReadableFileSizeString(torrent.dl_speed)
                             + '/s <i class="fa fa-long-arrow-up"></i> ' + getReadableFileSizeString(torrent.up_speed) + '/s</small>'
                         ),
-                        $('<td>').text(humanFileSize(torrent.size, 2)),
+                        $('<td>').text(humanFileSize(torrent.size, 2, true)),
                         $('<td>').text(ratio),
                         $('<td>').text(getReadableTime(torrent.eta)),
                         $('<td>').text(getStatusInfo(torrent)),

--- a/modules/radarr.py
+++ b/modules/radarr.py
@@ -228,10 +228,48 @@ class Radarr(object):
         return self.fetch(path='command', data=data, type='post')
 
     @cherrypy.expose()
+    @cherrypy.tools.json_out()
+    @require(member_of(htpc.role_admin))
+    def ToggleMonitor(self, id):
+        cherrypy.response.headers['Content-Type'] = 'application/json'
+        self.logger.debug('Toggling monitored status for id %s' % id)
+        m = self.fetch(path='movie/%s' % id, type='get')
+        if m['monitored'] == True:
+            m.update({"monitored": False})
+        else:
+            m.update({"monitored": True})
+        r = self.fetch(path='movie', data=m, type='put')
+        return self.fetch(path='movie/%s' % id, type='get')
+
+    @cherrypy.expose()
+    @require(member_of(htpc.role_admin))
+    def DeleteContent(self, **kwargs):
+        k = kwargs
+        cherrypy.response.headers['Content-Type'] = 'application/json'
+        data = {}
+        # deleteFiles = True appears to not work, wrong format?
+        # data['deleteFiles'] = k['deleteFiles']
+        data['deleteFiles'] = False
+        self.logger.debug('Deleting id %s' % k['id'])
+        return self.fetch(path='movie/%s' % k['id'], data=data, type='delete')
+
+    @cherrypy.expose()
     @require()
     @cherrypy.tools.json_out()
     def Lookup(self, q):
         return self.fetch('Movie/lookup?term=%s' % urllib.quote(q))
+
+    @cherrypy.expose()
+    @require()
+    @cherrypy.tools.json_out()
+    def Alerts(self):
+        return self.fetch('health')
+
+    @cherrypy.expose()
+    @require()
+    @cherrypy.tools.json_out()
+    def Queue(self):
+        return self.fetch('queue')
 
     @cherrypy.expose()
     @require()

--- a/modules/sonarr.py
+++ b/modules/sonarr.py
@@ -234,17 +234,72 @@ class Sonarr(object):
             data['name'] = k['method']
             if k['par'] == 'episodeIds':
                 k['id'] = [int(k['id'])]
-            data[k['par']] = k['id']
+                data[k['par']] = k['id']
+            if k['par'] == 'seriesId':
+                data['seriesId'] = k['id']
+                data['seasonNumber'] = k['sNum']
         except KeyError:
             pass
-
         return self.fetch(path='command', data=data, type='post')
+
+    @cherrypy.expose()
+    @cherrypy.tools.json_out()
+    @require(member_of(htpc.role_admin))
+    def ToggleMonitor(self, id):
+        cherrypy.response.headers['Content-Type'] = 'application/json'
+        self.logger.debug('Toggling monitored status for id %s' % id)
+        m = self.fetch(path='series/%s' % id, type='get')
+        if m['monitored'] == True:
+            m.update({"monitored": False})
+        else:
+            m.update({"monitored": True})
+        r = self.fetch(path='series', data=m, type='put')
+        return self.fetch(path='series/%s' % id, type='get')
+
+    @cherrypy.expose()
+    @cherrypy.tools.json_out()
+    @require(member_of(htpc.role_admin))
+    def ToggleMonitorSeason(self, id, sn):
+        cherrypy.response.headers['Content-Type'] = 'application/json'
+        sn = int(sn)
+        self.logger.debug('Toggling monitored status for id %s season %s' % (id,sn))
+        m = self.fetch(path='series/%s' % id, type='get')
+        if m['seasons'][sn]['monitored'] == True:
+            m['seasons'][sn]['monitored'] = False
+        else:
+            m['seasons'][sn]['monitored'] = True
+        r = self.fetch(path='series', data=m, type='put')
+        return self.fetch(path='series/%s' % id, type='get')
+
+    @cherrypy.expose()
+    @require(member_of(htpc.role_admin))
+    def DeleteContent(self, **kwargs):
+        k = kwargs
+        cherrypy.response.headers['Content-Type'] = 'application/json'
+        data = {}
+        # deleteFiles = True appears to not work, wrong format?
+        # data['deleteFiles'] = k['deleteFiles']
+        data['deleteFiles'] = False
+        self.logger.debug('Deleting id %s' % k['id'])
+        return self.fetch(path='series/%s' % k['id'], data=data, type='delete')
 
     @cherrypy.expose()
     @require()
     @cherrypy.tools.json_out()
     def Lookup(self, q):
         return self.fetch('Series/lookup?term=%s' % urllib.quote(q))
+
+    @cherrypy.expose()
+    @require()
+    @cherrypy.tools.json_out()
+    def Alerts(self):
+        return self.fetch('health')
+
+    @cherrypy.expose()
+    @require()
+    @cherrypy.tools.json_out()
+    def Queue(self):
+        return self.fetch('queue')
 
     @cherrypy.expose()
     @require()

--- a/modules/stats.py
+++ b/modules/stats.py
@@ -73,7 +73,9 @@ class Stats(object):
                 {'type': 'text', 'label': 'OHM IP', 'placeholder': 'localhost', 'name': 'stats_ohm_ip'},
                 {'type': 'text', 'label': 'OHM port', 'placeholder': '8085', 'desc': '', 'name': 'stats_ohm_port'},
                 {'type': 'bool', 'label': 'Enable S.M.A.R.T.', 'desc': 'smartmontools is used for grabbing HDD health info (python must be executed as administrator)', 'name': 'stats_smart_enabled'},
-                {'type': 'bool', 'label': 'Enable Scripts', 'desc': 'Add your scripts to userdata/scripts. Dont come crying if you delete your computer', 'name': 'stats_scripts_enabled'}
+                {'type': 'bool', 'label': 'Enable Scripts', 'desc': 'Add your scripts to userdata/scripts. Dont come crying if you delete your computer', 'name': 'stats_scripts_enabled'},
+                {'type': 'bool', 'label': 'Show last refresh time<br />on dashboard widget', 'desc': 'Enable dash widget status message', 'name': 'stats_dash_message_enabled'},
+                {'type': 'text', 'label': 'Reverse proxy link', 'placeholder': '', 'desc': 'Page title link. E.g /webmin or https://managementbox.mydomain.com/', 'name': 'stats_reverse_proxy_link'}
 
             ]
         })
@@ -87,7 +89,12 @@ class Stats(object):
                                                              cmdline=htpc.SHELL,
                                                              importpySMART=importpySMART,
                                                              importpySMARTerror=importpySMARTerror,
-                                                             scripts=self.list_scripts())
+                                                             scripts=self.list_scripts(),
+                                                             webinterface=self.webinterface())
+
+    def webinterface(self):
+    # Return the reverse proxy url if specified
+        return htpc.settings.get('stats_reverse_proxy_link')
 
     @cherrypy.expose()
     @require()
@@ -477,6 +484,7 @@ class Stats(object):
 
             d['stats_ignore_mountpoint'] = htpc.settings.get('stats_ignore_mountpoint')
             d['stats_ignore_filesystem'] = htpc.settings.get('stats_ignore_filesystem')
+            d['stats_dash_message_enabled'] = htpc.settings.get('stats_dash_message_enabled')
 
         except Exception as e:
             self.logger.error('Getting stats settings %s' % e)

--- a/modules/torrentsearch.py
+++ b/modules/torrentsearch.py
@@ -50,6 +50,7 @@ class Torrentsearch(object):
                 {'type': 'text', 'label': 'Jackett port', 'name': 'torrents_jackett_port'},
                 {'type': 'bool', 'label': 'Jackett ssl', 'name': 'torrents_jackett_ssl'},
                 {'type': 'password', 'label': 'Jackett apikey', 'name': 'torrents_jackett_apikey'},
+                {'type': 'text', 'label': 'Reverse proxy link', 'placeholder': '/jackett', 'desc': 'Page title link. E.g /jackett or https://rarbg.to/', 'name': 'torrents_reverse_proxy_link'}
 
             ]
         })
@@ -57,7 +58,11 @@ class Torrentsearch(object):
     @cherrypy.expose()
     @require()
     def index(self, query='', **kwargs):
-        return htpc.LOOKUP.get_template('torrentsearch.html').render(query=query, scriptname='torrentsearch', torrentproviders=self.torrentproviders())
+        return htpc.LOOKUP.get_template('torrentsearch.html').render(query=query, scriptname='torrentsearch', torrentproviders=self.torrentproviders(), webinterface=self.webinterface())
+
+    def webinterface(self):
+    # Return the reverse proxy url if specified
+        return htpc.settings.get('torrents_reverse_proxy_link')
 
     @cherrypy.expose()
     @require()


### PR DESCRIPTION
* uTorrent: set file size display to [KMG]iB to match native UI
* Dash: add status message functionality for all refreshable dash widgets
* Stats page: add 'reverse proxy' page header clickable link
* TorrentSearch page: add 'reverse proxy' page header clickable link
* Sonarr/Radarr: add action buttons
* Sonarr/Radarr: add health alerts tab
* Sonarr/Radarr: add dash widget refresh
* Sonarr/Radarr: expose health alerts on dash widgets